### PR TITLE
Internal server errors write a log

### DIFF
--- a/src/main/scala/api/services.scala
+++ b/src/main/scala/api/services.scala
@@ -62,6 +62,8 @@ trait FailureHandling {
 
 /**
  * Allows you to construct Spray ``HttpService`` from a concatenation of routes; and wires in the error handler.
+ * It also logs all internal server errors using ``SprayActorLogging``.
+ *
  * @param route the (concatenated) route
  */
 class RoutedHttpService(route: Route) extends Actor with HttpService with SprayActorLogging {


### PR DESCRIPTION
When you cause HTTP 500, the server now logs the error using `SprayActorLogging`.
