### PR TITLE
Update Cli.scala

### DIFF
--- a/src/main/scala/Cli.scala
+++ b/src/main/scala/Cli.scala
@@ -1,3 +1,3 @@
 import core.{BootedCore, CoreActors}
 
-object Cli extends App with CoreActors with BootedCore
+object Cli extends App with BootedCore with CoreActors


### PR DESCRIPTION
order of trait mixins as the article suggests BootedCore should be first and then CoreActors
