### PR TITLE
uses ToResponseMarshaller so the HTTP response code can be properly set

### DIFF
--- a/src/main/scala/api/DefaultJsonFormats.scala
+++ b/src/main/scala/api/DefaultJsonFormats.scala
@@ -3,7 +3,7 @@ package api
 import spray.json._
 import java.util.UUID
 import scala.reflect.ClassTag
-import spray.httpx.marshalling.{MetaMarshallers, Marshaller, CollectingMarshallingContext}
+import spray.httpx.marshalling.{ToResponseMarshaller, MetaMarshallers, Marshaller, CollectingMarshallingContext}
 import spray.http.StatusCode
 import spray.httpx.SprayJsonSupport
 
@@ -52,7 +52,7 @@ trait DefaultJsonFormats extends DefaultJsonProtocol with SprayJsonSupport with 
    * @tparam B the right projection
    * @return marshaller
    */
-  implicit def errorSelectingEitherMarshaller[A, B](implicit ma: Marshaller[A], mb: Marshaller[B], esa: ErrorSelector[A]): Marshaller[Either[A, B]] =
+  implicit def errorSelectingEitherMarshaller[A, B](implicit ma: Marshaller[A], mb: Marshaller[B], esa: ErrorSelector[A]): ToResponseMarshaller[Either[A, B]] =
     Marshaller[Either[A, B]] { (value, ctx) =>
       value match {
         case Left(a) =>


### PR DESCRIPTION
As per [spray-httpx ToResponseMarshaller](http://spray.io/documentation/1.2.1/spray-httpx/marshalling/#toresponsemarshaller) needed to change from Marshaller to ToResponseMarshaller to actually set the HTTP status code for the response.
