### PR TITLE
Fixed implicit marshalling of `Either` results with proper status setting

### DIFF
--- a/src/main/scala/api/DefaultJsonFormats.scala
+++ b/src/main/scala/api/DefaultJsonFormats.scala
@@ -3,7 +3,7 @@ package api
 import spray.json._
 import java.util.UUID
 import scala.reflect.ClassTag
-import spray.httpx.marshalling.{MetaMarshallers, Marshaller, CollectingMarshallingContext}
+import spray.httpx.marshalling.{MetaMarshallers, Marshaller, ToResponseMarshaller}
 import spray.http.StatusCode
 import spray.httpx.SprayJsonSupport
 
@@ -52,15 +52,13 @@ trait DefaultJsonFormats extends DefaultJsonProtocol with SprayJsonSupport with 
    * @tparam B the right projection
    * @return marshaller
    */
-  implicit def errorSelectingEitherMarshaller[A, B](implicit ma: Marshaller[A], mb: Marshaller[B], esa: ErrorSelector[A]): Marshaller[Either[A, B]] =
-    Marshaller[Either[A, B]] { (value, ctx) =>
+  implicit def errorSelectingEitherMarshaller[A, B](implicit ma: Marshaller[A], mb: Marshaller[B], esa: ErrorSelector[A]): ToResponseMarshaller[Either[A, B]] =
+    ToResponseMarshaller[Either[A, B]] { (value, ctx) =>
       value match {
         case Left(a) =>
-          val mc = new CollectingMarshallingContext()
-          ma(a, mc)
-          ctx.handleError(ErrorResponseException(esa(a), mc.entity))
+          ToResponseMarshaller.fromMarshaller(esa(a))(ma)(a, ctx)
         case Right(b) =>
-          mb(b, ctx)
+          ToResponseMarshaller.fromMarshaller()(mb)(b, ctx)
       }
     }
 

--- a/src/test/scala/api/RegistrationServiceSpec.scala
+++ b/src/test/scala/api/RegistrationServiceSpec.scala
@@ -3,13 +3,34 @@ package api
 import spray.testkit.Specs2RouteTest
 import spray.routing.Directives
 import org.specs2.mutable.Specification
-import spray.http.HttpResponse
+import spray.http.{HttpResponse, StatusCodes}
+import core.{Core, CoreActors, User}
+import core.RegistrationActor._
+import java.util.UUID
+import spray.httpx.SprayJsonSupport
 
-class RegistrationServiceSpec extends Specification with Directives with Specs2RouteTest {
+class RegistrationServiceSpec extends Specification with Directives with Specs2RouteTest with Core with CoreActors with DefaultJsonFormats {
+
+  private def mkUser(email: String): User = User(UUID.randomUUID(), "A", "B", email)
+
+
+  implicit val userFormat = jsonFormat4(User)
+  implicit val registerFormat = jsonFormat1(Register)
+
+  val badRegistration = Register(mkUser(""))
+
+  val routes = new RegistrationService(registration).route
 
   "The routing infrastructure should support" >> {
     "the most simple and direct route" in {
       Get() ~> complete(HttpResponse()) ~> (_.response) === HttpResponse()
+    }
+
+    "proper result status setting" in {
+      Post("/register", badRegistration) ~> routes ~> check {
+        handled.aka("register_request_is_handled") must beTrue
+        status must_== StatusCodes.BadRequest
+      }
     }
   }
 }


### PR DESCRIPTION
Currently the `implicit def errorSelectingEitherMarshaller[A, B](implicit ...` conversion is never used in the code hence there's no proper setting of the request status code. Refer to the [spray documentation on `ToResponseMarshaller`](http://spray.io/documentation/1.2.1/spray-httpx/marshalling/#toresponsemarshaller)

Also the once the conversion started working the only code returned was '500 Internal Server Error', so the result code setting had to be corrected, too.
